### PR TITLE
Add missing dependency for Python build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update && apt-get install -y \
   lib32z-dev \
   libgl1-mesa-dev \
   libxml2-utils \
+  libssl-dev \
   xsltproc \
   unzip \
   gawk \


### PR DESCRIPTION
for tools like AOSP Repo that rely on it